### PR TITLE
fix: Reset scroll on click

### DIFF
--- a/components/projects/ProjectSection.jsx
+++ b/components/projects/ProjectSection.jsx
@@ -23,11 +23,18 @@ const ProjectCard = () => {
       projects[index - 1] ? projects[index - 1] : projects[projects.length - 1]
     );
     setIndex(projects[index - 1] ? index - 1 : projects.length - 1);
+    scrollToTop();
   };
 
   const handleRightClick = () => {
     setProject(projects[index + 1] ? projects[index + 1] : projects[0]);
     setIndex(projects[index + 1] ? index + 1 : 0);
+    scrollToTop();
+  };
+
+  const scrollToTop = () => {
+    const paragraph = document.getElementById("project-description");
+    paragraph.scrollTop = 0;
   };
 
   return (
@@ -41,6 +48,7 @@ const ProjectCard = () => {
             onClick={() => {
               setProject(projects[idx]);
               setIndex(idx);
+              scrollToTop();
             }}
           >
             {p.title}
@@ -80,7 +88,10 @@ const ProjectCard = () => {
                 </p>
 
                 {/* Project Description */}
-                <p className="custom-scrollbar h-[168px] overflow-y-scroll pr-1 font-primary text-lg leading-6 tracking-[-0.4px]">
+                <p
+                  id="project-description"
+                  className="custom-scrollbar h-[168px] overflow-y-scroll pr-1 font-primary text-lg leading-6 tracking-[-0.4px]"
+                >
                   {project.description}
                 </p>
               </div>

--- a/constants/index.js
+++ b/constants/index.js
@@ -113,8 +113,8 @@ export const projects = [
     id: "project-5",
     type: "Front-End Web Development",
     imgUrl: img05,
-    title: "Meta Course Portfolio",
-    descriptionTitle: "A living portfolio showcasing my progress",
+    title: "Course Portfolio",
+    descriptionTitle: "Documenting My Front-End Dev Journey",
     description:
       "This site, developed in React, is a living portfolio showcasing my progress, challenges, and successes as I deepen my understanding of Front-End development. Throughout the course, I've applied what I've learned, and I've also explored topics beyond the curriculum, such as routing and tools like Tailwindcss. Here, you'll find examples of labs, projects, and practice exercises, all demonstrating key concepts and techniques.",
     gitUrl: "https://github.com/briansegs/meta-front-end_react-app",


### PR DESCRIPTION
Problem: 
If the user scrolled down while reading a project's description and then switched projects, the scroll position would stay in the same place.  

fix: 
The scroll position now resets to the top when a project is changed.